### PR TITLE
Update sequence diagrams for user scenarios to fetch estimate cost from Ant

### DIFF
--- a/docs/sequence-diagrams-for-user-scenarios.md
+++ b/docs/sequence-diagrams-for-user-scenarios.md
@@ -677,13 +677,14 @@ sequenceDiagram
     Browser->>Butterfly: Request Recommend infra model List with selected source model spec and image
     activate Butterfly
 	
-
+    %% Retrieve the recommendation models list from Beetle
 	Butterfly->>Beetle: API call to GET /beetle/recommendation/mci
 	activate Beetle
 	Beetle-->>Butterfly: Return the recommendation infra model based on selected source model spec and image
 	deactivate Beetle
 
 
+    %% Retrieve estimate cost infromations from Ant
 	loop For each recommendation infra model
 		activate Ant
         Butterfly->>Ant: API call to POST /ant/api/v1/cost/estimate api

--- a/docs/sequence-diagrams-for-user-scenarios.md
+++ b/docs/sequence-diagrams-for-user-scenarios.md
@@ -672,13 +672,13 @@ sequenceDiagram
     participant Spider as "Spider"
 	
 
-    User->>Browser: Select Source Group and Access to View Recommend infra model List
+    User->>Browser: Access to a view of the Recommended List (a list of servers)
     activate Browser
-    Browser->>Butterfly: Request Recommend infra model List with selected source model spec and image
+    Browser->>Butterfly: Request the Recommended Infra Model (a list of servers) with selected source model spec and image
     activate Butterfly
 	
     %% Retrieve the recommendation models list from Beetle
-	Butterfly->>Beetle: API call to GET /beetle/recommendation/mci
+	Butterfly->>Beetle: API call to POST /beetle/recommendation/mci
 	activate Beetle
 	Beetle-->>Butterfly: Return the recommendation infra model based on selected source model spec and image
 	deactivate Beetle
@@ -687,7 +687,7 @@ sequenceDiagram
     %% Retrieve estimate cost infromations from Ant
 	loop For each recommendation infra model
 		activate Ant
-        Butterfly->>Ant: API call to POST /ant/api/v1/cost/estimate api
+        Butterfly->>Ant: API call to POST /ant/api/v1/cost/estimate
         
         alt If Ant db does not have requested spec
             Ant->>Spider: API call to POST /spider/priceinfo/{ProductFamily}/{RegionName}

--- a/docs/sequence-diagrams-for-user-scenarios.md
+++ b/docs/sequence-diagrams-for-user-scenarios.md
@@ -657,12 +657,9 @@ sequenceDiagram
 ```
 
 
-## Estimate price for the migrated cloud infrastructure
+## Estimate cost for the recommend infra based on selected source model
 
-: Participants: Butterfly, Ant, Beetle, 
-
-> [!IMPORTANT] 
-> Question) Price 정보는 사전에 Spider에서 조회 후 관리하는 것으로 이해하고 있어 아래 다이어그램에 반영하지 않았습니다. 가격 추청에 대한 API가 맞는지 확인 바랍니다.
+: Participants: Butterfly, Beetle, Ant, Spider
 
 
 ```mermaid
@@ -670,40 +667,40 @@ sequenceDiagram
     participant User as "User"
     participant Browser as "Web Console"
     participant Butterfly as "Butterfly"
-    participant Tumblebug as "Tumblebug"
-    participant Damselfly as "Damselfly"
+    participant Beetle as "Beetle"
     participant Ant as "Ant"
+    participant Spider as "Spider"
 	
-	%% Step 0: User accesses Migration Status and Progress Management View
-    User->>Browser: Access the Migration Status and Progress Management view
+
+    User->>Browser: Select Source Group and Access to View Recommend infra model List
     activate Browser
-    Browser->>Butterfly: Request the Migration Status and Progress Management view
+    Browser->>Butterfly: Request Recommend infra model List with selected source model spec and image
     activate Butterfly
 	
-	%% Retrieve the target model list from Damselfly	
-	Butterfly->>Damselfly: API call to GET /damselfly/cloudmodel
-	activate Damselfly
-	Damselfly-->>Butterfly: Return the target model (cloud model) list
-	deactivate Damselfly
-		
-	%% Get the migrated infra info in case the mci info is used 
-	opt Retrieve the migrated infra (mci) list from Tumblebug
-	    Butterfly->>Tumblebug: API call to GET /tumblebug/ns/{nsId}/mci
-	    activate Tumblebug
-	    Tumblebug-->>Butterfly: Return the migrated infra (mci) list
-	    deactivate Tumblebug
-	end
 
-	%% Estimate/retrieve price info of all target models
-	loop For each target model
-	    Butterfly->>Ant: API call to GET /ant/api/v1/price/info
+	Butterfly->>Beetle: API call to GET /beetle/recommendation/mci
+	activate Beetle
+	Beetle-->>Butterfly: Return the recommendation infra model based on selected source model spec and image
+	deactivate Beetle
+
+
+	loop For each recommendation infra model
 		activate Ant
-		Ant-->>Butterfly: Return pricing information
+        Butterfly->>Ant: API call to POST /ant/api/v1/cost/estimate api
+        
+        alt If Ant db does not have requested spec
+            Ant->>Spider: API call to POST /spider/priceinfo/{ProductFamily}/{RegionName}
+            Spider-->>Ant: Return price info response
+        else If Ant db has requested spec
+            Ant ->> Ant: Query price info for spec and save in DB
+        end    
+		Ant-->>Butterfly: Return cost estimate response
 		deactivate Ant
 	end
-	Butterfly-->>Browser: Respond with the target model with pricing information
+
+	Butterfly-->>Browser: Respond with the target model with estimate cost information
     deactivate Butterfly
-    Browser-->>User: Display the target model with pricing information
+    Browser-->>User: Display the recommended infra model with estimate cost informantion
     deactivate Browser
 
 ```


### PR DESCRIPTION
@yunkon-kim 
Ant 를 통해 가격 조회하는 흐름을 콘솔 사용자의 흐름에 맞게 재정의했습니다.
전체적인 흐름은 다음과 같습니다.
- 사용자는 Honeybee 에서 조회한 소스 모델 중 하나를 선택하여 추천 리스트 페이지로 진입
- 선택된 소스 모델을 기반으로 Beetle 의 추천 모델 API  호출
- 추천 모델 API 호출 결과의 Spec 과 Image 를 통해 Ant 의 비용 추정 API 호출
- 비용 추정 API 응답 결과를 추천 모델 리스트와 함께 웹 브라우저 노출