### PR TITLE
Finalize user scenarios of software migration for v0.4.0 release

### DIFF
--- a/docs/v0.4.0-user-scenario-for-software-migration.md
+++ b/docs/v0.4.0-user-scenario-for-software-migration.md
@@ -2,29 +2,25 @@
 
 The sequence diagrams represent user scenarios for software migration.
 
-> [!NOTE]
-> Cloud-Migrator v0.4.0 통합 및 릴리스를 위한 Sequence Diagram 입니다.
-
-> [!NOTE]
-> Sequence Diagram은 대부분 2단계로 구성될 것 입니다. 다음 예시를 참고 바랍니다.
->
-> 1. (사용자가 포털에서 페이지를 요청하는 단계)
->
-> - Butterfly(서버)는 이를 위해 Subsystem들의 API를 호출하고
-> - 얻은 정보를 바탕으로 View를 구성 및 제공하는 단계
->
-> 2. (사용자가 해당 View 에서 마이그레이션을 요청하는 단계)
->
-> - 마이그레이션에 필요한 정보를 입력 후 마이그레이션을 요청하고,
-> - Butterfly(서버)가 관련 Subsystem 들의 API를 호출을 통해 마이그레이션을 수행 및 결과를 제공하는 단계
+> [!IMPORTANT]
+> 원활한 Cloud-Migrator v0.4.0 통합 및 릴리스를 위한 Sequence Diagram 입니다.
+> 이번 통합 테스트 및 릴리스를 위하여 사용자 시나리오 개선이 필요합니다. 🙏
 
 > [!TIP]
-> 수정, 보완이 필요한 사항들에 대해 많은 의견을 부탁드립니다.
-> 제안) 수정/보완 사항을 PR로 오픈하고 논의하면 좋을 것 같습니다. 🙌
+> 수정/보완 사항들은 PR로 오픈하여 논의/협의를 진행해 주시기 바랍니다. 🙌
 
 ## Login
 
 : Participants: Butterfly
+
+> [!NOTE]
+>
+> - 사용자가 Cloud-Migrator 웹 콘솔에 로그인하는 과정을 나타냅니다.
+> - 주요 흐름:
+>   - --> 사용자가 웹 콘솔 접근
+>   - --> 로그인 페이지 표시
+>   - --> 로그인 자격 증명 입력 및 검증
+>   - --> 대시보드 페이지로 이동
 
 [View Mermaid in Full Screen](https://mermaid.live/view#pako:eNqdVNtqGzEQ_ZVBEGhhbbyO7V3vQ6Bx-hgoMWmg-EVZTdaCXWmri13X-N872htu4zaketKMzhwdHWl0ZLkWyDJm8btHleOd5IXh1UYBjZobJ3NZc-Xg0aIBbmHDwmzDXiNujd4PoCd8hpVWVpd4CUvLazS7Hn3rnUPzUh4CtkVfXcHaYQ1xBp_yHK0Ft0VYldqL0b0kjU4bON-lqQraRjc3nZR3lfLcyR132J-jzXYBcQ6SM3gIZlkHHHYS9-A0lLqQ6g-eoaDND-HoXOADOm9UI_ACl8C_sZ2tDHp_N26awWdFrrZ8kBsUqJzkpb1s1T_B7zBnjUq8poEPYT_FK4zgC7d2r434-D-GfeWlFAHNaRvTuie43T5rbgS9sQLfsq5XTayPDeWdtHXJD2_RdHUsYhWaiktBbXMMqA2j66vonWc0FfjCfenCQz4RlHun1weVs8wZjxEz2hfbPvB1OEnXcn2S-uOb1uchy47sB8uu42Q8maXJIo6v54tpsozYgWXzZEyJeBFPltM0TeNkforYz4ZgMp7PCEpjMk2X8XwWscIE2Z0Uuig0K-2VI5qIoZDUGPftf9B8C6dfNsBh3g)
 
@@ -41,6 +37,7 @@ sequenceDiagram
     activate WebServer
     WebServer-->>Browser: Return the view to login
     deactivate WebServer
+    Browser-->User: Display login page
     deactivate Browser
 
     %% Step 2: Enter login credentials
@@ -56,7 +53,17 @@ sequenceDiagram
 
 ## Register the source computing environment and extract software information
 
+: Note - This process discovers and extracts unprocessed/raw software metadata from the source environment.
 : Participants: Butterfly, Honeybee, Source computing environment
+
+> [!NOTE]
+>
+> - 소스 컴퓨팅 환경을 등록하고 원시(unprocessed) 소프트웨어 메타데이터를 탐지 및 추출하는 과정을 나타냅니다.
+> - 주요 흐름:
+>   - --> 소스 그룹 등록 및 ID 생성
+>   - --> 연결 정보 등록 및 에이전트 설치
+>   - --> 소스 서버에서 원시 소프트웨어 패키지, 컨테이너, 서비스 정보 탐지 및 추출
+> - 추출된 소프트웨어 정보는 미가공 상태의 메타데이터로, 후속 정제 과정이 필요합니다.
 
 [View Mermaid in Full Screen](https://mermaid.live/view#pako:eNqtV9tu4jAQ_RXLUqVWolzaUmgekHZL1eVhtVXZi7RCqlwzgLXEztoOLYv49x3HSQi3cml5wU5mzozPnBPCjHLVBxpQA39jkBzagg01C3uS4Cdi2gouIiYt-WFAE2aS7_W7v-D5VkmjxuBicEfS7Xro59ha0IPx1EXmm_W4L0rC9BkSwGy9HtXV_E5OXExXxZoD1g2j2Ao5JHhdaCVDkLYnfebJCelaiEg1SM_DORgDbyeTr0yyISTLnwJePJTLP2-1FgcPyKcEjdgRkAnGETXYF9dDMm7FhFkosOlvLPZYMacsII9uaMYmFfc9wSQ_QV5uZQj59nzlfI9gIiX75EXYUX5Kn9OHbWiF3hHOsRaQtjDRmE2znrd02pEOh3FYK1HkZ3mwNdflUBjMzNDvtYqjrTPLo42PHi6iDx5HF5Acnc1E4XI39lbuW61M9Cishw7hbDx2oA_fut9JZZTeq3jop03Qy6bJduerErKxlsk0i12STpucmmGnfbZG_jLsfmIpjiKlXDMrlHSPiYHQod-cOkFVQjQRauDsGGV1R-pl-SC6WI0Xqh2gqouCTjBEAk_QOnKgdguLLxIEJnhCHLUfrbJ9C32k5CozV2BeWdR-Ejkru5TYavmnd4BMGuuK4djR-GpJj0jtBLRZgfSZ_qJfny_1n-raAwoP7zWASxubtekXAXd7JSMd-qu0b1PXMbZZnSjDG779D7BK9hAuFFnyyqLYAU65DMjdKyJw_GVWA_vCNCQ2WWJlg1uyJJMlFagkA63Ct9VwrHfgjbLvdc393S7TiDBS2lay4oea5laNx1BsPmL8D6rBlNxMLRMSiSr5OSJrAl9OjjPRxqGcbq4GlpfP3mmudCrore1zeaezcuC01s4fhwMMtQl7p5FoiYaAxUUfX8ZnLrBHkYsQejTAZR8GLB7bHu3JOYay2KruVHIaWB1DiaKqhqNsE0d9xE5f5LOL-LL8W6nilgYz-kqDy1qjXL1qNq5rtcv69UXjpkSnNKg3ynihdl2r3lw0m81aoz4v0X8JQLVcv8JQ_FQvmje1-lWJDrVrO20FLQb6VsXSIkyJQl9Ypb_6fxnJn435f4hkXV0)
 
@@ -129,11 +136,85 @@ sequenceDiagram
     deactivate WebConsole
 ```
 
+## Register or modify user's source software model
+
+: Note - This section handles the refined source software model that contains only migration-relevant information processed from unprocessed/raw software data.
+: Participants: Butterfly, Damselfly
+
+> [!NOTE]
+>
+> - 사용자의 소스 소프트웨어 모델을 등록하거나 수정하는 과정을 나타냅니다.
+> - 주요 흐름:
+>   - --> 소프트웨어 마이그레이션 모델 관리 뷰 로드
+>   - --> 마이그레이션에 필요한 정보만 정제한 소스 소프트웨어 모델 저장
+>   - --> JSON 에디터를 통한 소스 소프트웨어 모델 수정 및 버전 관리
+> - 소스 소프트웨어 모델은 원시 소프트웨어 메타데이터에서 마이그레이션에 필요한 정보만을 선별하고 정제한 데이터입니다.
+
+```mermaid
+sequenceDiagram
+    participant User as "User"
+    participant Browser as "Web Console"
+    participant Butterfly as "Butterfly"
+    participant Damselfly as "Damselfly"
+
+	%% Step 0: User accesses Software Migration Model Management View
+    User->>Browser: Access the Software Migration Model Management view
+    activate Browser
+    Browser->>Butterfly: Request the Software Migration Model Management view
+    activate Butterfly
+
+    Butterfly->>Damselfly: API call to GET /damselfly/softwaremodel/source (list source software models)
+    activate Damselfly
+    Damselfly-->>Butterfly: Return the source software model list
+    deactivate Damselfly
+
+    Butterfly-->>Browser: Respond with the view
+    deactivate Butterfly
+    Browser-->>User: Display Software Migration Model Management Interface
+    deactivate Browser
+
+    %% Save the original source software model
+    User->>Browser: Save original source software model request
+    activate Browser
+    Browser->>Butterfly: Request to save source software model
+    activate Butterfly
+    Butterfly->>Damselfly: API call to POST /damselfly/softwaremodel/source
+    activate Damselfly
+    Damselfly-->>Butterfly: Return the saved software model information
+    deactivate Damselfly
+    Butterfly-->>Browser: Respond with the save confirmation
+    deactivate Butterfly
+    Browser-->>User: Display the confirmation
+    deactivate Browser
+
+    %% Modify the software model on the JSON editor and save the model
+    User->>Browser: Modify source software model in JSON editor and save it
+    activate Browser
+    Browser->>Butterfly: Request to save modified source software model
+    activate Butterfly
+    Butterfly->>Damselfly: API call to PUT /damselfly/softwaremodel/source (modified data)
+    activate Damselfly
+    Damselfly-->>Butterfly: Return saved software model information (version specified)
+    deactivate Damselfly
+    Butterfly-->>Browser: Respond with the modification confirmation
+    deactivate Butterfly
+    Browser-->>User: Display the confirmation
+    deactivate Browser
+```
+
 ## Retrieve and refine software information from source environment, then save it
 
+: Note - This process retrieves raw software data and refines it into migration-relevant information that can be used to create source software models.
 : Participants: Butterfly, Honeybee, Damselfly
 
-- 해당 과정은 Honeybee로 부터 Source측의 정제된 Software 목록을 얻을 수 있는 Source의 Software Model 입니다.
+> [!NOTE]
+>
+> - 소스 환경에서 원시 소프트웨어 정보를 조회하고 마이그레이션에 필요한 정보로 정제하여 저장하는 과정을 나타냅니다.
+> - 주요 흐름:
+>   - --> 원시(unprocessed) 소프트웨어 데이터 조회
+>   - --> 마이그레이션 관련 정보만 선별한 정제된 소프트웨어 데이터 조회
+>   - --> 정제된 데이터를 소스 소프트웨어 모델로 저장 (선택적)
+> - 해당 과정은 Honeybee로부터 원시 소프트웨어 메타데이터를 정제하여 마이그레이션에 필요한 소프트웨어 목록을 얻는 과정입니다.
 
 [View Mermaid in Full Screen](https://mermaid.live/view#pako:eNq1lm1v2jAQx7-KZanSJtFCaCk0L5C2MnWd1LWCdZMmpMlNLmApsTPbKWOI777Lg8NTKCnb8gZ8Of_ufPeP7QX1pA_UpRp-JiA8GHA2USwaC4JPzJThHo-ZMORRgyJMZ7-7b98rOSscvsETuZZCyxAq_BJjQAXhPPUsB7t-H6WA-RNA6mb_73oNWKQhLGjlYCxyz5MTMjIQk5ZbJO95oDVoMpKBmTEF5I7jWg2XgtwxwSYQAUK_cpjlgHTWab9frM0l7zIAMVM4gHguEcwz_JkZsAXKrcUgZdsSuGSYdkCbI_GbpSyHp-v5D0HHUvhkxs00C7MC-bAXVeSKoMeMMuA6Dtn8QI63IoUwD3b5thKbXXJccgOGDNlsRR4ww6pbMQSjODwDUeivrb-P_iRQMkJTomzsY3ogidoboW7p-32rXJTOwy3xWBim5JsPX0hzWrxq5pn-mCiZxM2FntwOlk0bbivS5odgR6fbSzCJEvuyXuvDJq2GYg4j60pnt2lckE-j-88EfG6kqquZdqEZCLgA_3W6Kea82Nnj9FKH_P800yzi_412qlZA3gQ8REe0M1RErGS2m_pv_4Gw9lfsGHFVZv9qgd3H6ZbGwkxpLhkxbG26Z-a1X9EjPD_DfJaMTS2_KmFm8w7MqRZmHXHqnH4Iu1nhbWWWB6xLHu5HqEffGkrxZeTm-ua7EWDtiLbvSlO1FLNKYvL-VvbYz0CqKDt2VrC1hlaEqnkoZrXypAj4S_yqWu1T5Cuo640F4dMGjQAncB-vaIvUPKZIi2BMXfzrQ8CS0IzpWCzRlSVGjubCo65RCTQobg-TqR0kMX4H9npnjXiL-i7l-pC6C_qLuudO96x10eteOs5557LdvWrQOXU73TM0OJdO66rd6_WcbmfZoL8zQOusc4Gu-LTavSunc9GgE5WmXaSCiwF1LRNhENOg-Wd4l989syvo8g8ty56q)
 
@@ -202,31 +283,30 @@ sequenceDiagram
 
 ## Generate target software model, then save it
 
+: Note - This process generates the target software model by applying dependency analysis and filtering to the refined source software model.
 : Participants: Butterfly, Grasshopper, Honeybee, Damselfly
 
-- 해당 과정은 사용자가 클라우드에 SW 마이그레이션을 실행할 수 있는 상태/수준의 Software 목록(Target Software model)을 얻는 과정을 나타냅니다.
-- 사용자는 Portal을 통해 Honeybee로 부터 소스 컴퓨팅 환경의 정제된 Software 목록을 얻고 사용자가 원하는 Software들을 선택한 후, Target Software model을 요청합니다. 이 때, 내부적으로 Grasshopper API가 호출됩니다.
+> [!NOTE]
+>
+> - 정제된 소스 소프트웨어 모델을 기반으로 타겟 소프트웨어 모델을 생성하고 저장하는 과정을 나타냅니다.
+> - 주요 흐름:
+>   - --> 저장된 소스 소프트웨어 모델 목록 조회
+>   - --> 특정 소스 소프트웨어 모델 로드 및 선택
+>   - --> Grasshopper를 통한 의존성 분석 및 필터링 처리
+>   - --> 목표 환경에 적합한 타겟 소프트웨어 모델 생성 및 저장
+> - 해당 과정은 의존성 검사 및 처리를 통해 실제 마이그레이션 실행이 가능한 타겟 소프트웨어 모델을 생성합니다.
 
-- Migration List를 가져오는 Grasshopper API에 Honeybee로 부터 얻어온 Software 리스트를 전달하면 패키지 타입에 한해서 아래와 같은 패키지들을 제외하고 의존성으로 참조되는 패키지들을 제외 합니다.
-- Honeybee로 부터 얻어온 Software 리스트에는 메인 패키지외에 의존성으로 같이 존재하거나 환경 구성을 위해 존재하는 패키지들이 있습니다. 해당 패키지들은 주요 메인 패키지를 설치할때 같이 설치되어 지기 때문에, Grasshopper에서는 해당 패키지들을 필터링 하고 마이그레이션 리스트를 작성합니다.
-  - 라이브러리 패키지나 개발용 패키지(보통 lib으로 시작하거나, -dev로 끝나는 경우)
-  - 문서 패키지 (.\*-doc, .\*-man)
-  - 컨테이너 런타임 관련 패키지 (docker, podman, runc, ...)
-  - Kernel 관련 패키지 (linux-generic.\*, kernel.\*, ...)
-- 해당 동작은 Migration 과정을 단축시키고 동일한 패키지가 여러번 참조될 수 있는 중복 작업을 방지합니다.
-- 이 과정으로 인해 Grasshopper를 통해서 Target 쪽으로 Migration 수행시 실제로 참조되는 Software 목록을 확인 할 수 있습니다.
-- 이 목록은 Target에 Software들을 구성하기 위한 Target Software Model이 됩니다.
-
-1. 사용자는 Web Console을 통해 저장된 Source Software 목록을 조회합니다.
-2. Butterlfy 모듈이 Damselfly로 부터 저장된 Source Software 목록을 가져옵니다.
-3. Web Console에 저장된 Source Software 목록이 표출됩니다.
-4. 사용자가 Web Console을 통해 Target Software 목록 요청을 합니다.
-5. Butterfly 모듈이 Grasshopper 모듈로 Migration List를 가져오는 API에 Source Software 목록을 전달합니다.
-6. 패키지 타입에 한해서 의존성으로 같이 존재하거나 환경 구성을 위해 존재하는 패키지들을 제외 합니다.
-7. Web Console에 Software Migration List를 표출하게 됩니다. 이는 Target Software Model이 됩니다.
-8. 사용자가 Web Console을 통해 Target Software Model 저장 요청을 합니다.
-9. Butterlfy 모듈이 Damselfly 모듈로 Target Software Model을 저장하는 API를 요청합니다.
-10. 저장된 Target Software는 추후 Target에 Software Migration을 수행하는데 사용됩니다.
+> [!IMPORTANT] > **타겟 소프트웨어 모델 생성 과정**
+>
+> - 사용자는 Portal을 통해 Honeybee로부터 소스 컴퓨팅 환경의 정제된 소프트웨어 목록을 얻고 사용자가 원하는 소프트웨어들을 선택한 후, 타겟 소프트웨어 모델을 요청합니다.
+> - Grasshopper API에 Honeybee로부터 얻어온 소프트웨어 리스트를 전달하면 패키지 타입에 한해서 의존성으로 참조되는 패키지들을 제외합니다.
+> - **필터링되는 패키지 유형:**
+>   - 라이브러리 패키지나 개발용 패키지 (보통 lib으로 시작하거나, -dev로 끝나는 경우)
+>   - 문서 패키지 (_-doc, _-man)
+>   - 컨테이너 런타임 관련 패키지 (docker, podman, runc, ...)
+>   - Kernel 관련 패키지 (linux-generic._, kernel._, ...)
+>   - 환경 구성을 위해 존재하는 패키지들
+> - 해당 동작은 마이그레이션 과정을 단축시키고 동일한 패키지가 여러번 참조될 수 있는 중복 작업을 방지합니다.
 
 [View Mermaid in Full Screen](https://mermaid.live/view#pako:eNqtV21v2zYQ_iuEgAJuIb8lcewIRYCt6bJiTVfU6QYMBgZaOttEJFIjKTtekP_eI_ViWZJf4sZfLFIPnzvePccTnxxfBOB4joL_EuA-3DA6lzSacIK_mErNfBZTrsl3BZJQZf_rb3-VYpUB_oYp-SC4EiE04BKtQc7CtUEWgzruVlKlFiKOU87SsI79XXBYTwEMMH-uo25opCDMLBeDCU-Rb96QsYaY9Lxso74PSoEiYzHTKyqB3DGMi2aCkzvK6RwiQNK_GKxSArOqfX2dxcEjv1gCohdwgGJZUFBfsyXVkAcznc0GhjsPl0e-mWwpfSL9dti3A9A35FoyWAJRdAkB8ifSL5tBwYQkZGh-JkVUjqX1N2dHj4tXGI-vn4hPw5BoQW4_3pNukL_rqow5MsQ4suZa1oBZkE3kKGJh6m1lUxUvimG7GjidSJ56L2bZDpstpEQB7DJR3W45-99AxYIHZMX0wibJpIFQvsOW9admr5KnXAho57s1csNUHNL1AQF84oaEok3rzEvs5zLcVsiZRz4LijuJwWcz5jcLpLkqxhCCr20gwi2ORrdOLwtxCn0l3K-i4-4TC55JSxYltdejnxP1fm4SUE0PafoINb-A_FgBK6uKXYWIjJqyhnrcoc9zj9wCB2kg91TOQTdVyOdC8VWNlkQ0z3l0yrNxrODZVM5pOj3RxG6tllrltlq__jlGuc43rwvBdgtb_9qDsXUg0VWZ1rrzF4GzYol9dMub31iIbhKRaExjDDzAD441Nmn_AQ8r5b2fyu51GzMzlVRu5k0rmHbeueRdO4Dl2wx1I_zEnG9piDZYBAnfYCPKcyx-jaCCMM5EJlyzyOAQ9QDSJbEIEOmaN7is0-nki_4AyXG_ZS948ti2-WK-8efBIsxTadlHvmRScHv0KqzLuGBIQ1MKSHMVz2yQsBi2BUBaNS2XToxSVdSScUyHOkJ7J9T1ftqjd7Sjzi-wnWD7Jo0sB0tbHVh6WjUfz_riZpOW765uk4W6ZR2oxf0Veov9UGrcGfEFnzEZ2cy-RoMxW9jLeaz-mt09gr-c8uqJZky4pJSk-wXsDc-KYQKnQBIFgT0kZkI21QQ8gp-YJ8d1IkDfWID3sidjf-LgN2QEE8fDxwBmNAn1xJnwZ4TSRIvxmvuOp2UCriNFMl_kgyTG8zq_0-WTeB36R4jy0PGenEfHO-8PO72L0fCy3z8fXJ4Nr1xn7XiDYQcn-pf93tXZaDTqDwfPrvO_Jeh1BhcIxV_vbHTVH1y4zlwatzNXzBEvPwg8dJHGdSBgWsi79MJp753PPwCJtxJm)
 
@@ -244,13 +324,13 @@ sequenceDiagram
     activate Browser
     Browser->>Butterfly: Request the Software Migration Management view
     activate Butterfly
-    
+
     %% Step 1: Retrieve saved Source Software Model list from Damselfly
     Butterfly->>Damselfly: API call to GET /damselfly/softwaremodel/source (list all source software models)
     activate Damselfly
     Damselfly-->>Butterfly: Return list of saved source software models
     deactivate Damselfly
-    
+
     Butterfly-->>Browser: Respond with the view and source software model list
     deactivate Butterfly
     Browser-->>User: Display Software Migration Management Interface with source software model list
@@ -298,13 +378,95 @@ sequenceDiagram
     deactivate Butterfly
     Browser-->>User: Display Target Software Model save confirmation
     deactivate Browser
-    
+
     Note over User, Damselfly: The saved Target Software Model will be used<br/>for software migration execution
+```
+
+## Register or modify user's target software model
+
+: Note - This section handles the target software model that has been processed through dependency analysis and filtering, ready for migration execution.
+: Participants: Butterfly, Damselfly
+
+> [!NOTE]
+>
+> - 의존성 분석 및 필터링 처리를 거쳐 생성된 타겟 소프트웨어 모델을 등록하거나 수정하는 과정을 나타냅니다.
+> - 주요 흐름:
+>   - --> 소스 소프트웨어 모델 및 생성된 타겟 소프트웨어 모델 목록 조회
+>   - --> 마이그레이션 실행 준비가 완료된 타겟 소프트웨어 모델 저장
+>   - --> JSON 에디터를 통한 타겟 소프트웨어 모델 수정 및 버전 관리
+> - 타겟 소프트웨어 모델은 "Generate target software model" 과정에서 의존성 검사 및 처리를 거쳐 목표 환경에 맞게 최적화된 마이그레이션 실행용 메타데이터입니다.
+
+```mermaid
+sequenceDiagram
+    participant User as "User"
+    participant Browser as "Web Console"
+    participant Butterfly as "Butterfly"
+    participant Damselfly as "Damselfly"
+
+	%% Step 0: User accesses Software Migration Model Management View
+    User->>Browser: Access the Software Migration Model Management view
+    activate Browser
+    Browser->>Butterfly: Request the Software Migration Model Management view
+    activate Butterfly
+    opt Retrieve the source software models from Damselfly
+        Butterfly->>Damselfly: API call to GET /damselfly/softwaremodel/source
+        activate Damselfly
+        Damselfly-->>Butterfly: Return the source software model list
+        deactivate Damselfly
+    end
+    opt Retrieve the target software models from Damselfly
+        Butterfly->>Damselfly: API call to GET /damselfly/softwaremodel/target
+        activate Damselfly
+        Damselfly-->>Butterfly: Return the target software model list
+        deactivate Damselfly
+    end
+    Butterfly-->>Browser: Respond with the view
+    deactivate Butterfly
+    Browser-->>User: Display Software Migration Model Management Interface
+    deactivate Browser
+
+    %% Save the original target software model
+    User->>Browser: Save original target software model request
+    activate Browser
+    Browser->>Butterfly: Request to save target software model
+    activate Butterfly
+    Butterfly->>Damselfly: API call to POST /damselfly/softwaremodel/target
+    activate Damselfly
+    Damselfly-->>Butterfly: Return the saved software model information
+    deactivate Damselfly
+    Butterfly-->>Browser: Respond with the save confirmation
+    deactivate Butterfly
+    Browser-->>User: Display the confirmation
+    deactivate Browser
+
+    %% Modify the software model on the JSON editor and save the model
+    User->>Browser: Modify target software model in JSON editor and save it
+    activate Browser
+    Browser->>Butterfly: Request to save modified target software model
+    activate Butterfly
+    Butterfly->>Damselfly: API call to PUT /damselfly/softwaremodel/target (modified data)
+    activate Damselfly
+    Damselfly-->>Butterfly: Return saved software model information (version specified)
+    deactivate Damselfly
+    Butterfly-->>Browser: Respond with the modification confirmation
+    deactivate Butterfly
+    Browser-->>User: Display the confirmation
+    deactivate Browser
 ```
 
 ## Execute software migration
 
 : Participants: Butterfly, Cicada, Damselfly, Grasshopper, Honeybee, Beetle, Tumblebug
+
+> [!NOTE]
+>
+> - 타겟 소프트웨어 모델을 기반으로 실제 소프트웨어 마이그레이션을 실행하는 과정을 나타냅니다.
+> - 주요 흐름:
+>   - --> 타겟 소프트웨어 모델 선택 및 VM 관리
+>   - --> 소프트웨어 마이그레이션 워크플로우 템플릿 조회
+>   - --> 마이그레이션 워크플로우 생성 및 실행
+>   - --> Grasshopper를 통한 각 소프트웨어 패키지별 설치 및 구성
+>   - --> 워크플로우 실행 상태 및 결과 모니터링
 
 [View Mermaid in Full Screen](https://mermaid.live/view#pako:eNqtWW1P3DgQ_itWpEpUWrq8dkt0h8QBR_nAXY-lrXRCqkwyu1gkcWo7C3uI_35-TZy33SyFDxDvjp-Z8TzzEvMcRDSGIAw4_Cwgi-CM4DnD6W2G5E-OmSARyXEm0FcODGGu_7a__YPRRyvwHe7QKc04TaBDrhAC2CxZKsly0ZY7wymHxMqVi7bcKYlwjJWQeWpLXDDM-T3Nc2Odt2zLfqYZLO8AlKB77vABQCRaxjy1JW6K9C6Bu2KuhMpFW25KCxbBtyslZp7Rt6sOOMzmIIyYedZiRvDdOzQVkKOd0IYoioBzKCWndCYeMQN0JQOdoCuc4TmkIGG_EXg0GGrj9vGxDWKITjQGEvewHmVRouBIkAUW4MhgPrULBe_CHaJrxTYuXq-hzpzyJK5BMAILQBwvIO6G5tYuByEtKwkmXf9yiSKcJEhQdHF-g8ax-27MLUyqUMbCYG8lRPlhFk4CaRH-vmF1g8flcrt5OKJgGdLAdGZd6dZggGLoU9F01Q_yNfCcZjF6JOJeB0KdM8LZYF2NILhASx1ftYIzwvMEL9cH-DJTODiCtgrHpDrXd0M0hQQi0Y3dTWq7o9M5NKMMpURWPkFotjGdpyBPjVlO6_PkWllf3NDl2caEziEiMxKt8vhtKD1-JvEL2mItzZ2u_BrHu08nxgK_HbOHqxhK6DXBjUFg0pUv3WTeK-utrPBeVqhM_KcAtkQnC4mHZROREnxlxa4jyF8FIhnKKRM4eXWRroNuUI2N9Venl6aWzRhNay3T56v5vIOsZVaOMz5-zvhl_DJOI4K2ftbQR0hmsFpcnhltOvhGRvZSnKItmiuY30n8vknamlH6eXVJlnp4pY9vVGV7MNAazq3f2j557POmffw9BRJnGljRzxyfjIRieR1tYHMvU0VBkmxGO9F-nQ7jZ_nrUtWtn23X3w-PbN1J3QzvgbD-nPbOczANZEJpfQq-F3hgLWrE2G9jtjwNrUP7oaVN1VpKpO-UPcwS-ohuIJVqBawuQy1xy4PX9FbHpqrIllY9OjWibtXAwjTIT5M2_suFT1PzeQdNI_3F2Fk4Li10BB3kTrNO-Wb8ReUHdCEnfmeEpXLFiBIn_O2OjY-3rS744ZT_cCrt91HBhfTWY5BDsAIC8wcU0VRyWfWCiGYzMi-MsD18Y013llWmbRBNj7m-_4OzbQDu5sk2BLQ7zQ5CdMpACbRpN2RwVa-ByrWmASMUGdj2ib5uni01aFyFV5tw6-Y4K1Yn4LrU-fL3tJ07aKvXMXSHuewttGeQHFVGjrSV1eBmzd0swWzcVnDXJZoM4YrB0wqd5HniDZOtiFqxU5tk4B256qQs1bqt1BSEyc4Ychk9yCICpoHBE0SFtpKyGJiVv4AMVC2o1J6dXKzPYBMKz1g5bikltUqwMm83ydiSeRreOvzq7G3ZbntvPZ_cq9n6TD4M0bk-2-Gp7OTVaOTMefN8rQJeS9iWh2-apeNn96QmMlZkaAs8Z9tObpZ67uCaiTaVOSE6XLdf3zAyn0uYet_i6qXIXXhaySuaEUFZO4cao4O9cBQGuHafqPeqWzNGi_l9h1G19Do-9rZWDnYUFwO7tSC49_Bat5qlvedcyIZF-D2aTj-rPMrMHGb98jZKi9ydZyjLg6pc-kay2qPLTkNz_Zq0ClwFdQYRW-bCx5HUl6crCE7MYFFwks3R9fQE5czAPoAlo8PZbh6YLUixQYe4204vi-uWdrlf3tQa_6tyu_oIGhe85bLPZK9zmnG509wGape97vo47I1yw1K3odN5e8ncD-aMqEy0W5qUs1SuGKxeS6Rn9xW7cxw94DmoRFxxoZVQmqM_X7m5zsdaIL7msW7kAouCq5J2G5BMrpJE8vA20Jz8wqgOTqlVvwh0NvVKX9-RXst6eJJxokZH1YvuKH3Qp1K5otV7DU5TyQL0McnfJYs9LxJRbe6zqmLNKc2X9c6NZiSxY0N1Q6Z-3KY-SyKaE5mDevv647hhOOMzGZUO5Zs4cP4kmGSjrOVsQUypak4hQ4x32zkIIQkwwIFqJtNjpW5CFoUPD1-pV_Owy_Hh_J2RTGYsxLeBuhmSaznZqJXBkt3MT1KvzNRLgl9_OpLbPw5vOLDu1DuW5SN3J1R66Olota1243d9ud1Nw7LHyxyqOnwCXv-3B1VuNnY0R2B_YFJ3pfb7z9Jy9RatkNVxynAbb8zV-ID33Y6RzMbMwOgDerNpuank1YPyarNzRufS9N4X3mAUzBmJg1CwAkZBCnJuV8vgWe24DeQ4mMJtEMrHGGZY1SzJ0he5LcfZv5Smbqceo9yi0JG0_512H-JC0Okyi9xaAgThc_AUhPt7kw-TTwf7k6OdyWSyv7s3CpZBuH14uPvh6PDwYLK_I7-bHLyMgv-0xt0Pe58mR3uHu3uTj58Odyc7R1K_mgHZKS0yEYQfJxICYsXFK_Mfc_2P85f_AUzN2JE)
 
@@ -327,13 +489,13 @@ sequenceDiagram
     activate Browser
     Browser->>Butterfly: Request the Target Software Model Management view
     activate Butterfly
-    
+
     %% Retrieve saved Target Software Models
     Butterfly->>Damselfly: API call to GET /damselfly/softwaremodel/target (list target software models)
     activate Damselfly
     Damselfly-->>Butterfly: Return list of saved target software models
     deactivate Damselfly
-    
+
     Butterfly-->>Browser: Respond with the view and target software models
     deactivate Butterfly
     Browser-->>User: Display Target Software Model Management Interface
@@ -344,13 +506,13 @@ sequenceDiagram
     activate Browser
     Browser->>Butterfly: Send request with selected target software model ID
     activate Butterfly
-    
+
     %% Retrieve specific Target Software Model
     Butterfly->>Damselfly: API call to GET /damselfly/softwaremodel/target/{id} (retrieve specific target software model)
     activate Damselfly
     Damselfly-->>Butterfly: Return target software model data
     deactivate Damselfly
-    
+
     Butterfly-->>Browser: Respond with target software model data
     deactivate Butterfly
     Browser-->>User: Display selected target software model details
@@ -361,21 +523,21 @@ sequenceDiagram
     activate Browser
     Browser->>Butterfly: Request VM Management view
     activate Butterfly
-    
+
     %% Query MCI list from Beetle
     Butterfly->>Beetle: API call to GET /migration/ns/{nsId}/mci (query MCI list, or MCI ID list with query param (option=id))
     activate Beetle
     Beetle-->>Butterfly: Return list of MCIs or MCI IDs
-    Butterfly-->>Browser: Respond with the list of MCIs or MCI IDs 
-    Browser-->>User: Display the list of MCIs or MCI IDs 
-       
+    Butterfly-->>Browser: Respond with the list of MCIs or MCI IDs
+    Browser-->>User: Display the list of MCIs or MCI IDs
+
     %% Query available VMs from Beetle
-    User->>Browser: Select an MCI and query to get available VMs 
+    User->>Browser: Select an MCI and query to get available VMs
     Browser->>Butterfly: Request the selected MCI info to get available VMs
     Butterfly->>Beetle: API call to GET /migration/ns/{nsId}/mci/{mciId} (query available VMs)
     Beetle-->>Butterfly: Return list of available VMs and their details
     deactivate Beetle
-    
+
     Butterfly-->>Browser: Respond with VM list and details
     deactivate Butterfly
     Browser-->>User: Display available VMs for migration target
@@ -386,14 +548,14 @@ sequenceDiagram
     activate Browser
     Browser->>Butterfly: Request software migration workflow templates
     activate Butterfly
-    
+
     %% Query Software Migration Workflow Templates from Cicada
     Butterfly->>Cicada: API call to GET /cicada/workflow/templates (query software migration workflow templates)
     activate Cicada
     Note over Cicada: Return available templates:<br/>- migrate_software_workflow<br/>- custom migration templates<br/>- task component configurations
     Cicada-->>Butterfly: Return available software migration workflow templates
     deactivate Cicada
-    
+
     Butterfly-->>Browser: Respond with workflow templates
     deactivate Butterfly
     Browser-->>User: Display available workflow templates
@@ -422,49 +584,49 @@ sequenceDiagram
     Butterfly->>Cicada: API call to POST /cicada/workflow/{workflowId}/run (execute the migration workflow)
     activate Cicada
     Note over Cicada: Execute workflow:<br/>- Start workflow execution<br/>- Trigger task components in sequence<br/>- Monitor task dependencies
-    
+
     %% Cicada triggers Grasshopper tasks through workflow execution
     Cicada->>Grasshopper: Execute software migration tasks (via workflow)
     activate Grasshopper
-    
+
     %% Establish SSH connections
     Grasshopper->>Honeybee: Get source connection info
     activate Honeybee
     Note over Honeybee: Decrypt connection credentials<br/>using RSA private key
     Honeybee-->>Grasshopper: Return decrypted connection info
     deactivate Honeybee
-    
+
     Grasshopper->>Tumblebug: Get target VM connection info
     activate Tumblebug
     Tumblebug-->>Grasshopper: Return target VM access info
     deactivate Tumblebug
-    
+
     Grasshopper->>SourceVM: Establish SSH connection
     activate SourceVM
-    Grasshopper->>TargetVM: Establish SSH connection  
+    Grasshopper->>TargetVM: Establish SSH connection
     activate TargetVM
-    
+
     %% Execute migration for each software package in Target Software Model
     loop For each software package in Target Software Model
         Note over Grasshopper: Update status to "installing"<br/>Process software from target software model
         Grasshopper->>TargetVM: Run Ansible playbook for package installation
         TargetVM-->>Grasshopper: Return installation result
-        
+
         Grasshopper->>SourceVM: Copy configuration files and data
         SourceVM-->>Grasshopper: Return copied files
         Grasshopper->>TargetVM: Transfer configuration files
-        
+
         Grasshopper->>SourceVM: Extract service configuration
         SourceVM-->>Grasshopper: Return service settings
         Grasshopper->>TargetVM: Configure and start services
         TargetVM-->>Grasshopper: Return service status
-        
+
         Note over Grasshopper: Update status to "finished" or "failed"
     end
-    
+
     deactivate SourceVM
     deactivate TargetVM
-    
+
     Grasshopper-->>Cicada: Return migration task results and status
     deactivate Grasshopper
     Note over Cicada: Monitor workflow execution:<br/>- Track task completion<br/>- Update workflow status<br/>- Generate execution report<br/>- Handle task failures and retries
@@ -479,6 +641,14 @@ sequenceDiagram
 ## Monitor software migration progress and logs
 
 : Participants: Butterfly, Grasshopper
+
+> [!NOTE]
+>
+> - 소프트웨어 마이그레이션 진행 상황과 로그를 모니터링하는 과정을 나타냅니다.
+> - 주요 흐름:
+>   - --> 실시간 마이그레이션 상태 모니터링
+>   - --> 진행률 및 현재 처리 중인 패키지 확인
+>   - --> 상세한 마이그레이션 로그 조회 (설치 로그, 구성 로그, 에러 메시지)
 
 [View Mermaid in Full Screen](https://mermaid.live/view#pako:eNqlVmtr2zAU_StCUNjAeThtmtSMwJaWUlhHadcNRr6o1o0j6kieJKfNQv77rm3ZcRYnzTZ_sSWde3Qf58pa0VBxoAE18DMFGcKlYJFm84kk-CRMWxGKhElLHg1owkz-3l39pNWLA3yHJzJW0qgYGnCptaCn8TJDVoNd3LVmxsxUkhScteFEFuiTE_JgISHdwLkWhmAMGHIrMAArlCS3SgqrtJAR-SbgpbDLwK3RyDkckI-5HbEzaLZcVJYstGLBLJTBFrNukFGW4QTkPsumsX_Hup2Natiqe3sPJlGSkxdhZzn7hojDXirnIhI95iyXwiQxWza7diMzWxbCLm0Z93YF_KA0rxHeaRVpTGxz0kv8vMInW_jmVMdKJZVpaUBQE0JxEbK4jPfNsmy2NZbZ1GzM9qVwuyKjUU2QKKG7G5JtT6wi11dfSSfarHaMmtoXpqFTbAqdYsvOCl4hTDMnbvi6wYEtyZerXxSuqAXKfcuB8QzCZ1IRuqiCD0-6M2oRDYwvPSIkTscxltgjUyGFmQHHLyZi4A55V8tpCNKyCNzKONUaJ7BHw2ecJU-QSQVrkDcd33hY86v1Z_JtqmXmTdyyYg4HqlDTXGMajuiNfco63CmN3fKY8Ay6y0h40UeFLUh-bMf0gvxAqrXLZxXtaZUcyMHmdao5EVcW_3AuHabZdxD9l-xxoybN7y_0Hq2jjLSABeSelxJ32m7jHHnnBkV8RebMewesAi-goZJTEaUuFwzFgylbiLBgL42utM7OKqw4St8UMIuNQKzGY9Kl703hN-X8kNCPEHkli0bGY_8CW_nKgnvDU0dEPToHPWeC4_VhlaEmFP9Ic5jQAD85TFka2wmdyDVCWWrVw1KGNLA6BY9qlUazcpDmHeauHuUk3gN-KFUf0mBFX2lw6g_a3bPh4Nz3T_vnvcGFR5c06A_aOOGf-92L3nA49Af9tUd_5QTddv8Mofh0e8MLv3_m0UhnbjtXsHNBj1UqLdJ4FHj2g7kt7kX59Wj9G4U8Ktk)
 


### PR DESCRIPTION
- Renamed to v0.4.0-user-scenario-for-sofware-migration.md
- Added user's source and target model management section
- Finalized v0.4.0-user-scenario-for-sofware-migration.md

@ish-hcc 
- 파일명을 변경하고, 전체적으로 내용을 정리하였습니다. 
- 기존 파일을 참조하던 부분이 있다면, Broken link 이슈가 발생되니 참고 바랍니다.

@innodreamer
- 사용자의 SW 소스/ 목표 모델 관련 시나리오가 추가되었습니다.
- 살펴보시고, 수정이 필요하다면 추가 PR 올려주시기 바랍니다.
